### PR TITLE
use b.N instead of fixed value inside benchmark functions

### DIFF
--- a/gocha_test.go
+++ b/gocha_test.go
@@ -97,7 +97,7 @@ func TestRandFromRange(t *testing.T) {
 }
 
 func BenchmarkGen(b *testing.B) {
-	for count := 0; count < 100; count++ {
+	for i := 0; i < b.N; i++ {
 		_, g := New(`.{1000}`)
 		g.Gen()
 	}


### PR DESCRIPTION
We should use `b.N` as loop index inside benchmark functions for measuring performances exactly.

Before: 

```
$ go test -bench .
BenchmarkGen-4   	1000000000	         0.03 ns/op
PASS
ok  	_/Users/max747/devel/github/gocha	0.170s
```

After:

```
$ go test -bench .
BenchmarkGen-4   	    5000	    269177 ns/op
PASS
ok  	_/Users/max747/devel/github/gocha	1.382s
```